### PR TITLE
JIRA FLY2-48 Update Block addition (apply method) to accept blocks from Mir.

### DIFF
--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -992,7 +992,7 @@ func (c *Chain) processBatch( batch *msgs.QEntry) error{
 		}
 		if c.isConfig(env) {
 			configBlock := c.CreateBlock([]*common.Envelope{env})
-			c.writeConfigBlock(configBlock,)
+			c.writeConfigBlock(configBlock)
 		}else{
 			envs = append(envs,env)
 		}
@@ -1014,16 +1014,17 @@ func (c *Chain) Apply(batch *msgs.QEntry) error {
 		seqNumbers = append(seqNumbers, k)
 	}
 	sort.SliceStable(seqNumbers, func(i, j int) bool { return seqNumbers[i] < seqNumbers[j] })
-
-	for i:=0 ;i<len(seqNumbers)  ;i++{
+	for i:=0;i<len(seqNumbers);i++{
+		
 			if c.Node.LastCommittedSeqNo+1 != seqNumbers[i] {
 				break
 			}
 			err := c.processBatch(c.pendingBatches[seqNumbers[i]])
 			if err != nil {
-					return errors.WithMessage(err, "Batch Processing Error")}
+			    return errors.WithMessage(err, "Batch Processing Error")
+			}
 			delete(c.pendingBatches, seqNumbers[i])
-			c.Node.LastCommittedSeqNo = seqNumbers[i]
+			c.Node.LastCommittedSeqNo++
 	}
 	return nil
 }

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"encoding/pem"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -160,6 +161,8 @@ type Chain struct {
 	errorC     chan struct{} // returned by Errored()
 
 	mirbftMetadataLock   sync.RWMutex
+	//JIRA FLY2-48 - proposed changes:map to store the pending batches before committing
+	pendingBatches        map[uint64]*msgs.QEntry
 	confChangeInProgress *raftpb.ConfChange
 	justElected          bool // this is true when node has just been elected
 	configInflight       bool // this is true when there is config block or ConfChange in flight
@@ -200,6 +203,7 @@ type Chain struct {
 	// BCCSP instance
 	CryptoProvider bccsp.BCCSP
 }
+
 
 type MirBFTLogger struct {
 	*flogging.FabricLogger
@@ -563,7 +567,7 @@ func (c *Chain) run() {
 
 }
 
-func (c *Chain) writeBlock(block *common.Block, index uint64) {
+func (c *Chain) writeBlock(block *common.Block) {
 	if block.Header.Number > c.lastBlock.Header.Number+1 {
 		c.logger.Panicf("Got block [%d], expect block [%d]", block.Header.Number, c.lastBlock.Header.Number+1)
 	} else if block.Header.Number < c.lastBlock.Header.Number+1 {
@@ -576,19 +580,17 @@ func (c *Chain) writeBlock(block *common.Block, index uint64) {
 	}
 	c.lastBlock = block
 
-	c.logger.Infof("Writing block [%d] (Raft index: %d) to ledger", block.Header.Number, index)
-
-	if protoutil.IsConfigBlock(block) {
-		c.writeConfigBlock(block, index)
-		return
-	}
+	c.logger.Infof("Writing block [%d] to ledger", block.Header.Number)
 
 	c.mirbftMetadataLock.Lock()
-	c.opts.BlockMetadata.RaftIndex = index
+	c.appliedIndex++
+	c.opts.BlockMetadata.RaftIndex = c.appliedIndex
+
 	m := protoutil.MarshalOrPanic(c.opts.BlockMetadata)
 	c.mirbftMetadataLock.Unlock()
 
 	c.support.WriteBlock(block, m)
+
 }
 
 // Orders the envelope in the `msg` content. SubmitRequest.
@@ -631,10 +633,16 @@ func (c *Chain) proposeMsg(msg *orderer.SubmitRequest) (err error) {
 	if err != nil {
 		return errors.Errorf("failed to generate next request number")
 	}
+
+	//FLY2-48-proposed change:In apply function,Block generation requires *Common.Envelope rather than payload data byte .*Common.Envelope helps to identify request id config or not
+	data,err := proto.Marshal(msg.Payload)
+	if err != nil {
+		return errors.Errorf("Cannot marshal payload")
+	}
 	req := &msgs.Request{
 		ClientId: clientID,
 		ReqNo:    reqNo,
-		Data:     msg.Payload.GetPayload(),
+		Data:     data,
 	}
 
 	reqBytes, err := proto.Marshal(req)
@@ -799,7 +807,14 @@ func pemToDER(pemBytes []byte, id uint64, certType string, logger *flogging.Fabr
 // writeConfigBlock writes configuration blocks into the ledger in
 // addition extracts updates about raft replica set and if there
 // are changes updates cluster membership as well
-func (c *Chain) writeConfigBlock(block *common.Block, index uint64) {
+func (c *Chain) writeConfigBlock(block *common.Block) {
+	c.mirbftMetadataLock.Lock()
+	c.appliedIndex++
+	c.opts.BlockMetadata.RaftIndex = c.appliedIndex
+	m := protoutil.MarshalOrPanic(c.opts.BlockMetadata)
+	c.mirbftMetadataLock.Unlock()
+	c.support.WriteConfigBlock(block,m)
+	c.lastBlock = block
 
 }
 
@@ -945,10 +960,82 @@ func (c *Chain) triggerCatchup(sn *raftpb.Snapshot) {
 	case <-c.doneC:
 	}
 }
+//JIRA FLY2-48 proposed changes: fetch request from request store
+func (c *Chain) fetchRequest(ack *msgs.RequestAck) (*msgs.Request,error){
 
-// TODO(harrymknight) Implement these methods
-func (c *Chain) Apply(*msgs.QEntry) error {
+	reqByte, err := c.Node.ReqStore.GetRequest(ack)
+	if err != nil {
+		return nil, errors.WithMessage(err, "Cannot Fetch Request")
+	}
+	if reqByte == nil {
+		return nil,errors.Errorf("reqstore should have request if we are committing it")
+	}
+	reqMsg := &msgs.Request{}
+	err = proto.Unmarshal(reqByte,reqMsg)
+	if err != nil {
+		return nil,errors.WithMessage(err, "Cannot Unmarshal Request")
+	}
+	return reqMsg,nil
+}
+//FLY2-48 proposed changes
+// - convert batches to block and write to the ledger
+func (c *Chain) processBatch( batch *msgs.QEntry) error{
+	var envs []*common.Envelope
+	for _, requestAck := range batch.Requests {
+		reqMsg,err := c.fetchRequest(requestAck)
+		if err != nil {
+			return errors.WithMessage(err, "Cannot fetch request from Request Store")
+		}
+		env,err:= protoutil.UnmarshalEnvelope(reqMsg.Data)
+		if err != nil {
+			return errors.WithMessage(err, "Cannot Unmarshal Request Data")
+		}
+		if c.isConfig(env) {
+			configBlock := c.CreateBlock([]*common.Envelope{env})
+			c.writeConfigBlock(configBlock,)
+		}else{
+			envs = append(envs,env)
+		}
+	}
+	if len(envs)!=0 {
+		block := c.CreateBlock(envs)
+		c.writeBlock(block)
+	}
+
 	return nil
+}
+
+
+//JIRA FLY2-48 proposed changes:Write block in accordence with the sequence number
+func (c *Chain) Apply(batch *msgs.QEntry) error {
+	c.pendingBatches[batch.SeqNo] = batch
+	seqNumbers := make([]uint64, 0, len(c.pendingBatches))
+	for k := range c.pendingBatches {
+		seqNumbers = append(seqNumbers, k)
+	}
+	sort.SliceStable(seqNumbers, func(i, j int) bool { return seqNumbers[i] < seqNumbers[j] })
+
+	for i:=0 ;i<len(seqNumbers)  ;i++{
+			if c.Node.LastCommittedSeqNo+1 != seqNumbers[i] {
+				break
+			}
+			err := c.processBatch(c.pendingBatches[seqNumbers[i]])
+			if err != nil {
+					return errors.WithMessage(err, "Batch Processing Error")}
+			delete(c.pendingBatches, seqNumbers[i])
+			c.Node.LastCommittedSeqNo = seqNumbers[i]
+	}
+	return nil
+}
+//FLY2-48 proposed changes
+//	- create Blocks
+func (c *Chain ) CreateBlock(envs []*common.Envelope) *common.Block {
+	bc := &blockCreator{
+		hash:   protoutil.BlockHeaderHash(c.lastBlock.Header),
+		number: c.lastBlock.Header.Number,
+		logger: c.logger,
+	}
+	return bc.createNextBlock(envs)
 }
 
 //JIRA FLY2-66 proposed changes:Implemented the Snap Function

--- a/orderer/consensus/hlmirbft/node.go
+++ b/orderer/consensus/hlmirbft/node.go
@@ -45,6 +45,10 @@ type node struct {
 
 	CheckpointSeqNo         uint64                  //JIRA FLY2-66
 	PendingReconfigurations []*msgs.Reconfiguration //JIRA FLY2-66
+	
+	LastCommittedSeqNo uint64 //JIRA FLY2-48 - proposed changes: To track the last committed sequence number
+	
+	ReqStore *reqstore.Store //JIRA FLY2-48 - Stores the request store instance of mirbft node. This for getting Request object using request #.
 
 	rpc RPC
 
@@ -74,6 +78,9 @@ func (n *node) start(fresh, join bool) {
 			n.logger.Error(err, "Failed to create WAL")
 		}
 		reqStore, err := reqstore.Open(n.ReqStoreDir)
+		//FL2-48 proposed changes
+		// - store the mirbft node request store instance to node
+		n.ReqStore = reqStore
 		if err != nil {
 			n.logger.Error(err, "Failed to create request store")
 		}


### PR DESCRIPTION

The block addition routine should accept blocks from Mir as well as from Raft, but not at the same time.

Currently block creation in Raft presumes that only one leader is ordering the batches which are to be written as blocks. This meant that an index could simply be incremented each time the block writer was called and then used as the block number.

There are now multiple leaders ordering blocks meaning the sequence numbers, which uniquely identify the batches, are spread across the leaders using modulo arithmetic e.g. in the simplest case of 4 leaders each with a single bucket the sequence numbers for the first epoch will be distributed like so:
0-3 for first leader
4-7 for second leader
8-11 for third leader
12-16 for forth leader

In such case the block writer could receive batch with sequence number 4 before batch with sequence number 0 (due to asynchronicity) . We therefore need to ensure that before a batch with a given sequence number is converted to a block all batches prior to it have been written to the chain.

Configuration transactions must also be written as their own block. Since these will be grouped with regular transactions (as they must be ordered) inside batches we need a way of extracting these whilst retaining order.

#### Type of change

- New feature


#### Description

To ensure sequential writing of blocks, in the apply() function:-

Create a variable to track the last committed sequence number (LastSeqNo)

Increment LastSeqNo and Check if the sequence number of the received batch is equal to the LastSeqNo, if yes, write the block

If not, add the block to a Map object which stores the sequence number and block details as key and value respectively  

Periodically check if the map object contains the block with the subsequent sequence number. 





#### Related issues

FLY2-64 and FLY2-57



