### PR TITLE
FLY2-94 Resolve forward flag with actual request forwarding

### DIFF
--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -624,7 +624,7 @@ func (c *Chain) checkMsg(msg *orderer.SubmitRequest) (err error) {
 func (c *Chain) proposeMsg(msg *orderer.SubmitRequest, sender uint64) (err error) {
 	clientID := sender
 	proposer := c.Node.Client(clientID)
-	//The reqNo of a client should only ever be incremented by the node the client belongs to
+	//Incrementation of the reqNo of a client should only ever be caused by the node the client belongs to
 	reqNo, err := proposer.NextReqNo()
 
 	if err != nil {

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -477,7 +477,9 @@ func (c *Chain) Consensus(req *orderer.ConsensusRequest, sender uint64) error {
 	// Check if the request is a forwarded transaction
 	switch t := stepMsg.Type.(type) {
 	case *msgs.Msg_ForwardRequest:
-		// If this forwarded request has no acknowledgements then we know it is a forwarded transaction
+		// If this forwarded request has no acknowledgements
+		// then it has only been sent to a node by a Fabric application
+		// and then forwarded to at least f+1 nodes
 		if t.ForwardRequest.RequestAck == nil {
 			forwardedReq := &orderer.SubmitRequest{}
 			if err := proto.Unmarshal(t.ForwardRequest.RequestData, forwardedReq); err != nil {

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -474,6 +474,22 @@ func (c *Chain) Consensus(req *orderer.ConsensusRequest, sender uint64) error {
 		return fmt.Errorf("failed to unmarshal StepRequest payload to Raft Message: %s", err)
 	}
 
+	// Check if the request is a forwarded transaction
+	switch t := stepMsg.Type.(type) {
+	case *msgs.Msg_ForwardRequest:
+		// If this forwarded request has no acknowledgements then we know it is a forwarded transaction
+		if t.ForwardRequest.RequestAck == nil {
+			forwardedReq := &orderer.SubmitRequest{}
+			if err := proto.Unmarshal(t.ForwardRequest.RequestData, forwardedReq); err != nil {
+				return fmt.Errorf("failed to unmarshal ForwardedRequest payload to SubmitRequest: %s", err)
+			}
+			if err := c.checkMsg(forwardedReq); err != nil {
+				return err
+			}
+			return c.proposeMsg(forwardedReq, sender)
+		}
+	}
+
 	if err := c.Node.Step(context.TODO(), sender, stepMsg); err != nil {
 		return fmt.Errorf("failed to process Raft Step message: %s", err)
 	}

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -550,12 +550,12 @@ func (c *Chain) Submit(req *orderer.SubmitRequest, sender uint64) error {
 		}
 	}
 
+	if err := c.checkMsg(req); err != nil {
+		return err
 	}
 
-	req.Payload.Payload = submitPayload[9:]
-
-	return c.ordered(req)
-
+	//This request was sent by a Fabric application
+	return c.proposeMsg(req, c.MirBFTID)
 }
 
 type apply struct {

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -463,7 +463,7 @@ func (c *Chain) isRunning() error {
 	return nil
 }
 
-// Consensus passes the given ConsensusRequest message to the raft.Node instance
+// Consensus passes the given ConsensusRequest message to the mirbft.Node instance
 func (c *Chain) Consensus(req *orderer.ConsensusRequest, sender uint64) error {
 	if err := c.isRunning(); err != nil {
 		return err

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -591,34 +591,25 @@ func (c *Chain) writeBlock(block *common.Block, index uint64) {
 	c.support.WriteBlock(block, m)
 }
 
-// Orders the envelope in the `msg` content. SubmitRequest.
+// Checks the envelope in the `msg` content. SubmitRequest.
 // Returns
 //   -- err error; the error encountered, if any.
-// It takes care of config messages as well as the revalidation of messages if the config sequence has advanced.
+// It takes care of the revalidation of messages if the config sequence has advanced.
 
-//JIRA FLY2-57 - proposed changes
-func (c *Chain) ordered(msg *orderer.SubmitRequest) (err error) {
-
+//JIRA FLY2-57 - proposed changes -> adapted in JIRA FLY2-94
+func (c *Chain) checkMsg(msg *orderer.SubmitRequest) (err error) {
 	seq := c.support.Sequence()
 
 	if msg.LastValidationSeq < seq {
-
-		if c.isConfig(msg.Payload) {
-
-			c.configInflight = true //JIRA FLY2-57 - proposed changes
-		}
-
 		c.logger.Warnf("Normal message was validated against %d, although current config seq has advanced (%d)", msg.LastValidationSeq, seq)
 
 		if _, err := c.support.ProcessNormalMsg(msg.Payload); err != nil {
 			c.Metrics.ProposalFailures.Add(1)
 			return errors.Errorf("bad normal message: %s", err)
 		}
-
 	}
 
-	return c.proposeMsg(msg)
-
+	return nil
 }
 
 //FLY2-57 - Proposed Change: New function to propose normal messages to node

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -612,11 +612,11 @@ func (c *Chain) checkMsg(msg *orderer.SubmitRequest) (err error) {
 	return nil
 }
 
-//FLY2-57 - Proposed Change: New function to propose normal messages to node
-func (c *Chain) proposeMsg(msg *orderer.SubmitRequest) (err error) {
-
-	clientID := c.MirBFTID
+//FLY2-57 - Proposed Change: New function to propose normal messages to node -> adapted in JIRA FLY2-94
+func (c *Chain) proposeMsg(msg *orderer.SubmitRequest, sender uint64) (err error) {
+	clientID := sender
 	proposer := c.Node.Client(clientID)
+	//The reqNo of a client should only ever be incremented by the node the client belongs to
 	reqNo, err := proposer.NextReqNo()
 
 	if err != nil {


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Instead of prepending a special flag and then resubmitting the endorsed transaction using the `Submit` API; submitted transactions are now wrapped into Mir `forwardRequests` and then broadcast using the `Consensus` API. 

#### Additional details

At the reception point of the `Consensus` API the message is checked to see if it is a forwarded transaction (denoted by an endorsed transaction wrapped into an otherwise empty Mir `forwardRequest`). If it is, the transaction is proposed as before.