### PR TITLE
FlY2- 59 Catchup solution --WaitReady 

### DIFF
--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -392,10 +392,8 @@ func (c *Chain) Configure(env *common.Envelope, configSeq uint64) error {
 //
 // In any other case, it returns right away.
 func (c *Chain) WaitReady() error {
-	if err := c.isRunning(); err != nil {
-		return err
-	}
-
+	
+   // FLY2-59 JIRA issue
 	return nil
 }
 


### PR DESCRIPTION
#### Type of change

- New feature


#### Description
Catchup solution --WaitReady
In Raft WaitReady is called when a node is catching up with the others in the network. It halts the ingress messages which would otherwise be dropped by the node. As a Mir-BFT node has access to a request store that can buffer the ingress messages it receives this method no longer has to be implemented and instead should return nil. Note even with reqstore node may not catch up. Account for this.
