### PR TITLE
FLY2-169 Resolve faulty evaluation of checkpoints during epoch change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.14
 
 require (
 	code.cloudfoundry.org/clock v1.0.0
-	github.com/766b/go-outliner v0.0.0-20180511142203-fc6edecdadd7 // indirect
 	github.com/DataDog/zstd v1.4.8 // indirect
 	github.com/Knetic/govaluate v3.0.0+incompatible
 	github.com/Shopify/sarama v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxo
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 code.cloudfoundry.org/clock v1.0.0 h1:kFXWQM4bxYvdBw2X8BbBeXwQNgfoWv1vqAk2ZZyBN2o=
 code.cloudfoundry.org/clock v1.0.0/go.mod h1:QD9Lzhd/ux6eNQVUDVRJX/RKTigpewimNYBi7ivZKY8=
-github.com/766b/go-outliner v0.0.0-20180511142203-fc6edecdadd7 h1:cJXisB2yAM61AzMutv7X+KM8F3xVLxGH99S8VmaSlps=
-github.com/766b/go-outliner v0.0.0-20180511142203-fc6edecdadd7/go.mod h1:1SzhThoS5lcKfE4IFOLQJ04WCmFpaAiPe8H9yqXyYSU=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
@@ -112,12 +110,10 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-
 github.com/fly2plan/fabric-config v0.1.1-0.20210720100109-69fb94527cd9 h1:wmC33elVjAhnKDWw/KKil1qDPWazKW3kNIbZ62TUUaU=
 github.com/fly2plan/fabric-config v0.1.1-0.20210720100109-69fb94527cd9/go.mod h1:sWh7tvruTcvTytqCGYSt3Uv+IffgddGArkUjS1RajHc=
 github.com/fly2plan/fabric-protos-go v0.0.0-20210720095300-b410e4bf46cf h1:omXUkCLNsZIgl6uraHOZmtEz01y4ThEEDN8Y+PvL3hM=
 github.com/fly2plan/fabric-protos-go v0.0.0-20210720095300-b410e4bf46cf/go.mod h1:CZfaIgb8BFAclJMvz3enh03TZXzqj6wyBE7RYlwi5H0=
-
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -1247,7 +1247,10 @@ func (c *Chain) Snap(networkConfig *msgs.NetworkState_Config, clientsState []*ms
 
 	}
 	//JIRA FLY2-106 Generating last block bytes to be added to snap data
-	lastBlockBytes, err := proto.Marshal(c.lastBlock)
+	lastBlockBytes, err := proto.Marshal(&common.Block{
+		Header: c.lastBlock.Header,
+		Data:   c.lastBlock.Data,
+	})
 	if err != nil {
 
 		return nil, nil, errors.WithMessage(err, "Could not marshal block")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,8 +2,6 @@
 ## explicit
 code.cloudfoundry.org/clock
 code.cloudfoundry.org/clock/fakeclock
-# github.com/766b/go-outliner v0.0.0-20180511142203-fc6edecdadd7
-## explicit
 # github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
 github.com/Azure/go-ansiterm
 github.com/Azure/go-ansiterm/winterm
@@ -129,8 +127,6 @@ github.com/eapache/go-xerial-snappy
 # github.com/eapache/queue v1.1.0
 ## explicit
 github.com/eapache/queue
-
-
 # github.com/fly2plan/fabric-config v0.1.1-0.20210720100109-69fb94527cd9
 ## explicit
 github.com/fly2plan/fabric-config/protolator
@@ -141,7 +137,6 @@ github.com/fly2plan/fabric-config/protolator/protoext/mspext
 github.com/fly2plan/fabric-config/protolator/protoext/ordererext
 github.com/fly2plan/fabric-config/protolator/protoext/peerext
 # github.com/fly2plan/fabric-protos-go v0.0.0-20210720095300-b410e4bf46cf
-
 ## explicit
 github.com/fly2plan/fabric-protos-go/orderer/hlmirbft
 # github.com/frankban/quicktest v1.11.3


### PR DESCRIPTION
Following start-up the Mir state machine would halt at an epoch change due to inconsistent checkpoints. This fix omits the metadata of the snapped last block thereby ensuring consistent checkpoints.

#### Type

- Bug fix

#### Description

The metadata of the snapped block was subject to a race condition as the encoding of a blocks metadata is an asynchronous process.