### PR TITLE
FLY2-194 Remove redundant batch sequencing

### DIFF
--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"github.com/hyperledger/fabric/common/configtx"
 	"reflect"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -1136,7 +1136,6 @@ func (c *Chain) processBatch(batch *msgs.QEntry) error {
 
 		} else {
 			envs = append(envs, env)
-
 		}
 	}
 	if len(envs) != 0 {
@@ -1297,9 +1296,7 @@ func (c *Chain) TransferTo(seqNo uint64, snap []byte) (*msgs.NetworkState, error
 	//JIRA FLY2-106 using block data to catch up and synchronise with rest of the nodes
 	err := c.catchUp(blockBytes)
 	if err != nil {
-
 		return nil, errors.WithMessage(err, "Catchup failed")
-
 	}
 
 	if err := proto.Unmarshal(networkStateBytes, networkState); err != nil {


### PR DESCRIPTION
The Mir library already sorts the order of the batches before passing them to Fabric to be written as blocks. Therefore the code which does this Fabric side can be safely removed.