### PR TITLE
FLY2-195 Overhaul Fabric request forwarding

### DIFF
--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -684,7 +684,7 @@ func (c *Chain) getNewReconfiguration(envelope *common.Envelope) ([]*msgs.Reconf
 // It takes care of the revalidation of messages if the config sequence has advanced.
 
 //JIRA FLY2-57 - proposed changes -> adapted in JIRA FLY2-94
-func (c *Chain) checkMsg(msg *orderer.SubmitRequest) (err error) {
+func (c *Chain) checkReq(msg *orderer.SubmitRequest) (err error) {
 	seq := c.support.Sequence()
 
 	if msg.LastValidationSeq < seq {


### PR DESCRIPTION
The current implementation of Fabric request forwarding relies on the Consensus RPC layer, which can be overfilled, and a request forwarding flag to label forwarded requests. Furthermore the way requests are proposed leads to faulty crash recovery.

The new implementation of Fabric request forwarding uses the Submit RPC layer and no longer relies on a forwarding flag. Requests are also dealt with in a deterministic way so that all nodes have the same view of a request.