### PR TITLE
FLY2-192 Implement crash recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ TESTS*.xml
 .tox/
 .vagrant/
 .vscode
+./vendor

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/fly2plan/fabric-config v0.1.1-0.20210720100109-69fb94527cd9
 	github.com/fly2plan/fabric-protos-go v0.0.0-20210720095300-b410e4bf46cf
+	github.com/fly2plan/mirbft v0.0.0-20210924102818-ec2fd5c13c1e
 	github.com/frankban/quicktest v1.11.3 // indirect
 	github.com/fsouza/go-dockerclient v1.7.0
 	github.com/go-kit/kit v0.9.0
@@ -29,7 +30,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 	github.com/hashicorp/go-version v1.2.0
-	github.com/hyperledger-labs/mirbft v0.0.0-20210513065819-2525f29404f5
+	github.com/hyperledger-labs/mirbft v0.0.0-20210708125254-8da2c6b5145c
 	github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20201119163726-f8ef75b17719
 	github.com/hyperledger/fabric-config v0.1.0
@@ -66,17 +67,12 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
-	golang.org/x/mod v0.4.2 // indirect
-	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20210521090106-6ca3eb03dfc2 // indirect
-	golang.org/x/tools v0.1.0
+	golang.org/x/tools v0.1.6
 	google.golang.org/grpc v1.31.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	honnef.co/go/tools v0.1.3 // indirect
 )
 
 replace github.com/onsi/gomega => github.com/onsi/gomega v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,9 @@ code.cloudfoundry.org/clock v1.0.0 h1:kFXWQM4bxYvdBw2X8BbBeXwQNgfoWv1vqAk2ZZyBN2
 code.cloudfoundry.org/clock v1.0.0/go.mod h1:QD9Lzhd/ux6eNQVUDVRJX/RKTigpewimNYBi7ivZKY8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
+github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.8 h1:Rpmta4xZ/MgZnriKNd24iZMhGpP5dvUcs/uqfBapKZY=
 github.com/DataDog/zstd v1.4.8/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
@@ -114,6 +115,8 @@ github.com/fly2plan/fabric-config v0.1.1-0.20210720100109-69fb94527cd9 h1:wmC33e
 github.com/fly2plan/fabric-config v0.1.1-0.20210720100109-69fb94527cd9/go.mod h1:sWh7tvruTcvTytqCGYSt3Uv+IffgddGArkUjS1RajHc=
 github.com/fly2plan/fabric-protos-go v0.0.0-20210720095300-b410e4bf46cf h1:omXUkCLNsZIgl6uraHOZmtEz01y4ThEEDN8Y+PvL3hM=
 github.com/fly2plan/fabric-protos-go v0.0.0-20210720095300-b410e4bf46cf/go.mod h1:CZfaIgb8BFAclJMvz3enh03TZXzqj6wyBE7RYlwi5H0=
+github.com/fly2plan/mirbft v0.0.0-20210924102818-ec2fd5c13c1e h1:7OoVJQZuoP84NCAIEZ1Lsiuc/u9s9fB/fKIgxMw3P/w=
+github.com/fly2plan/mirbft v0.0.0-20210924102818-ec2fd5c13c1e/go.mod h1:oy5Y2A45J0U6NPT7w+O928u/kvQJ3c66wndHMYKzgmE=
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -184,8 +187,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger-labs/mirbft v0.0.0-20210513065819-2525f29404f5 h1:0auDwvre9JJzqi3+kharf8noa22CIfHmIvY481p7VrY=
-github.com/hyperledger-labs/mirbft v0.0.0-20210513065819-2525f29404f5/go.mod h1:1YhUDXFBn3X9gprvl8MAud3KF/MbA8Qvl+MvPW8Hqmg=
+github.com/hyperledger-labs/mirbft v0.0.0-20210708125254-8da2c6b5145c h1:Wb9ir1Za+kwy3EMOWqD/hsGmg3cL2NQKjsfX+RLn9ok=
+github.com/hyperledger-labs/mirbft v0.0.0-20210708125254-8da2c6b5145c/go.mod h1:1YhUDXFBn3X9gprvl8MAud3KF/MbA8Qvl+MvPW8Hqmg=
 github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a h1:JAKZdGuUIjVmES0X31YUD7UqMR2rz/kxLluJuGvsXPk=
 github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
 github.com/hyperledger/fabric-chaincode-go v0.0.0-20201119163726-f8ef75b17719 h1:FQ9AMLVSFt5QW2YBLraXW5V4Au6aFFpSl4xKFARM58Y=
@@ -382,6 +385,7 @@ github.com/willf/bitset v1.1.10/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPy
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.etcd.io/bbolt v1.3.1-etcd.7/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20181228115726-23731bf9ba55 h1:YTC92EdyM9lnD0aVRqN28/CILPLZSzdmoomOFAjxBbk=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20181228115726-23731bf9ba55/go.mod h1:weASp41xM3dk0YHg1s/W8ecdGP5G4teSTMBPpYAaUgA=
@@ -419,8 +423,9 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
+golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -435,8 +440,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 h1:ADo5wSpq2gqaCGQWzk7S5vd//0iyyLeAratkEoG5dLE=
-golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=
+golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -476,8 +481,9 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210521090106-6ca3eb03dfc2 h1:48AqIJLs69Wmc3mA52aIcqt544rjrDCqolKAv7L8leA=
-golang.org/x/sys v0.0.0-20210521090106-6ca3eb03dfc2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210923061019-b8560ed6a9b7 h1:c20P3CcPbopVp2f7099WLOqSNKURf30Z0uq66HpijZY=
+golang.org/x/sys v0.0.0-20210923061019-b8560ed6a9b7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201113234701-d7a72108b828/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
@@ -501,8 +507,9 @@ golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.6 h1:SIasE1FVIQOWz2GEAHFOmoW7xchJcqlucjSULTL0Ag4=
+golang.org/x/tools v0.1.6/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -574,5 +581,5 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.1.3 h1:qTakTkI6ni6LFD5sBwwsdSO+AQqbSIxOauHTTQKZ/7o=
-honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
+honnef.co/go/tools v0.2.1 h1:/EPr//+UMMXwMTkXvCCoaJDq8cpjMO80Ou+L4PDo2mY=
+honnef.co/go/tools v0.2.1/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -21,8 +21,8 @@ import (
 
 	"code.cloudfoundry.org/clock"
 	"github.com/fly2plan/fabric-protos-go/orderer/hlmirbft"
+	"github.com/fly2plan/mirbft"
 	"github.com/golang/protobuf/proto"
-	"github.com/hyperledger-labs/mirbft"
 	"github.com/hyperledger-labs/mirbft/pkg/pb/msgs"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/orderer"

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"github.com/hyperledger/fabric/common/configtx"
 	"reflect"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -717,6 +717,7 @@ func (c *Chain) checkMsg(msg *orderer.SubmitRequest) (err error) {
 func (c *Chain) proposeMsg(msg *orderer.SubmitRequest, sender uint64) (err error) {
 	clientID := sender
 	proposer := c.Node.Client(clientID)
+	c.mirbftMetadataLock.Lock()
 	//Incrementation of the reqNo of a client should only ever be caused by the node the client belongs to
 	reqNo, err := proposer.NextReqNo()
 
@@ -744,6 +745,7 @@ func (c *Chain) proposeMsg(msg *orderer.SubmitRequest, sender uint64) (err error
 	}
 
 	err = proposer.Propose(context.Background(), reqNo, reqBytes)
+	c.mirbftMetadataLock.Unlock()
 
 	if err != nil {
 		return errors.WithMessagef(err, "failed to propose message to client %d", clientID)

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -1136,7 +1136,6 @@ func (c *Chain) processBatch(batch *msgs.QEntry) error {
 
 		} else {
 			envs = append(envs, env)
-
 		}
 	}
 	if len(envs) != 0 {
@@ -1297,9 +1296,7 @@ func (c *Chain) TransferTo(seqNo uint64, snap []byte) (*msgs.NetworkState, error
 	//JIRA FLY2-106 using block data to catch up and synchronise with rest of the nodes
 	err := c.catchUp(blockBytes)
 	if err != nil {
-
 		return nil, errors.WithMessage(err, "Catchup failed")
-
 	}
 
 	if err := proto.Unmarshal(networkStateBytes, networkState); err != nil {

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -534,8 +534,7 @@ func (c *Chain) Submit(req *orderer.SubmitRequest, sender uint64) error {
 			forwardedReqBytes := protoutil.MarshalOrPanic(forwardedReq)
 			err := c.Node.rpc.SendConsensus(nodeID, &orderer.ConsensusRequest{Channel: c.channelID, Payload: forwardedReqBytes})
 			if err != nil {
-				c.logger.Warnf("Failed to broadcast Message to Node : %d ", nodeID)
-				return err
+				c.logger.Warnf("Failed to broadcast Message to Node : %d with error : %x", nodeID, err)
 			}
 		}
 	}

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -684,7 +684,7 @@ func (c *Chain) getNewReconfiguration(envelope *common.Envelope) ([]*msgs.Reconf
 // It takes care of the revalidation of messages if the config sequence has advanced.
 
 //JIRA FLY2-57 - proposed changes -> adapted in JIRA FLY2-94
-func (c *Chain) checkMsg(msg *orderer.SubmitRequest) (err error) {
+func (c *Chain) checkReq(msg *orderer.SubmitRequest) (err error) {
 	seq := c.support.Sequence()
 
 	if msg.LastValidationSeq < seq {

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -247,11 +247,11 @@ func NewChain(
 
 	wal, err := simplewal.Open(opts.WALDir)
 	if err != nil {
-		lg.Error(err, "could not open WAL")
+		lg.Error(err, "Could not open WAL")
 	}
 	fresh, err := wal.IsEmpty()
 	if err != nil {
-		lg.Error(err, "could not query WAL")
+		lg.Error(err, "Could not query WAL")
 	}
 
 	b := support.Block(support.Height() - 1)

--- a/orderer/consensus/hlmirbft/chain.go
+++ b/orderer/consensus/hlmirbft/chain.go
@@ -1306,7 +1306,6 @@ func (c *Chain) TransferTo(seqNo uint64, snap []byte) (*msgs.NetworkState, error
 	snapData := &hlmirbft.SnapData{}
 	networkState := &msgs.NetworkState{}
 	if err := proto.Unmarshal(snap, snapData); err != nil {
-
 		return nil, err
 	}
 	//JIRA FLY2-106 retrieving network state bytes and block bytes from snap data
@@ -1321,9 +1320,7 @@ func (c *Chain) TransferTo(seqNo uint64, snap []byte) (*msgs.NetworkState, error
 	}
 
 	if err := proto.Unmarshal(networkStateBytes, networkState); err != nil {
-
 		return nil, err
-
 	}
 
 	return networkState, nil

--- a/orderer/consensus/hlmirbft/node.go
+++ b/orderer/consensus/hlmirbft/node.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/fly2plan/fabric-protos-go/orderer/hlmirbft"
-	"github.com/hyperledger-labs/mirbft"
+	"github.com/fly2plan/mirbft"
 	"github.com/hyperledger-labs/mirbft/pkg/eventlog"
 	"github.com/hyperledger-labs/mirbft/pkg/pb/msgs"
 	"github.com/hyperledger-labs/mirbft/pkg/reqstore"
@@ -68,52 +68,52 @@ const (
 func (n *node) start(fresh, join bool) {
 	n.logger.Debugf("Starting mirbft node: #peers: %v", len(n.metadata.ConsenterIds))
 
-		if join {
-			n.logger.Info("Starting mirbft node to join an existing channel")
-		} else {
-			n.logger.Info("Starting mirbft node as part of a new channel")
-		}
+	if join {
+		n.logger.Info("Starting mirbft node to join an existing channel")
+	} else {
+		n.logger.Info("Starting mirbft node as part of a new channel")
+	}
 
-		// Checking if the configuration settings have been passed correctly.
-		err := os.MkdirAll(n.ReqStoreDir, 0700)
-		if err != nil {
-			n.logger.Error(err, "Failed to create WAL directory")
-		}
-		wal, err := simplewal.Open(n.WALDir)
-		if err != nil {
-			n.logger.Error(err, "Failed to create WAL")
-		}
-		err = os.MkdirAll(n.ReqStoreDir, 0700)
-		if err != nil {
-			n.logger.Error(err, "Failed to create request store directory")
-		}
-		reqStore, err := reqstore.Open(n.ReqStoreDir)
-		//FL2-48 proposed changes
-		// - store the mirbft node request store instance to node
-		n.ReqStore = reqStore
-		if err != nil {
-			n.logger.Error(err, "Failed to create request store")
-		}
-		node, err := mirbft.NewNode(
-			n.chain.MirBFTID,
-			n.config,
-			&mirbft.ProcessorConfig{
-				Link:         n,
-				Hasher:       crypto.SHA256,
-				App:          n.chain,
-				WAL:          wal,
-				RequestStore: reqStore,
-				Interceptor:  eventlog.NewRecorder(n.chain.MirBFTID, &bytes.Buffer{}),
-			},
-		)
-		if err != nil {
-			n.logger.Error(err, "Failed to create mirbft node")
-		} else {
-			n.Node = *node
-		}
+	// Checking if the configuration settings have been passed correctly.
+	err := os.MkdirAll(n.ReqStoreDir, 0700)
+	if err != nil {
+		n.logger.Error(err, "Failed to create WAL directory")
+	}
+	wal, err := simplewal.Open(n.WALDir)
+	if err != nil {
+		n.logger.Error(err, "Failed to create WAL")
+	}
+	err = os.MkdirAll(n.ReqStoreDir, 0700)
+	if err != nil {
+		n.logger.Error(err, "Failed to create request store directory")
+	}
+	reqStore, err := reqstore.Open(n.ReqStoreDir)
+	//FL2-48 proposed changes
+	// - store the mirbft node request store instance to node
+	n.ReqStore = reqStore
+	if err != nil {
+		n.logger.Error(err, "Failed to create request store")
+	}
+	node, err := mirbft.NewNode(
+		n.chain.MirBFTID,
+		n.config,
+		&mirbft.ProcessorConfig{
+			Link:         n,
+			Hasher:       crypto.SHA256,
+			App:          n.chain,
+			WAL:          wal,
+			RequestStore: reqStore,
+			Interceptor:  eventlog.NewRecorder(n.chain.MirBFTID, &bytes.Buffer{}),
+		},
+	)
+	if err != nil {
+		n.logger.Error(err, "Failed to create mirbft node")
+	} else {
+		n.Node = *node
+	}
 
-		initialNetworkState := InitialNetworkState(len(n.chain.opts.Consenters))
-		//FLY2-167 - Restructured the if condition
+	initialNetworkState := InitialNetworkState(len(n.chain.opts.Consenters))
+	//FLY2-167 - Restructured the if condition
 	if fresh {
 		// TODO(harrymknight) Tick interval is fixed. Perhaps introduce TickInterval field in configuration options
 		go func() {

--- a/vendor/github.com/BurntSushi/toml/.gitignore
+++ b/vendor/github.com/BurntSushi/toml/.gitignore
@@ -1,5 +1,2 @@
-TAGS
-tags
-.*.swp
-tomlcheck/tomlcheck
 toml.test
+/toml-test


### PR DESCRIPTION
NOTE:
Branches FLY2-194 and FLY2-195 should be merged prior to merging this branch.

If an ordering node which is participating in consensus goes down (due to crashing or maintenance) its underlying Mir state machine will loop upon reinitialising. This is because the state machine lacks the state (comprising of a leader choice and the current network config) it should transfer to.

On completion of this ticket, the node will safely receive this desired state at an epoch transition, and then catch up to this state the other nodes have agreed upon through the state transfer mechanism.